### PR TITLE
Fix typo when passing attributes to normalizer method

### DIFF
--- a/lib/misp/galaxy_cluster.rb
+++ b/lib/misp/galaxy_cluster.rb
@@ -26,7 +26,7 @@ module MISP
     attr_reader :meta
 
     def initialize(**attributes)
-      attributes = normalize_attributes(attributes)
+      attributes = normalize_attributes(**attributes)
 
       @id = attributes.dig(:id)
       @uuid = attributes.dig(:uuid)

--- a/lib/misp/sharing_group_org.rb
+++ b/lib/misp/sharing_group_org.rb
@@ -15,7 +15,7 @@ module MISP
     attr_reader :organization
 
     def initialize(**attributes)
-      attributes = normalize_attributes(attributes)
+      attributes = normalize_attributes(**attributes)
 
       @id = attributes.dig(:id)
       @sharing_group_id = attributes.dig(:sharing_group_id)


### PR DESCRIPTION
Seems to be a typo/mistake in these two classes.
